### PR TITLE
Bug Fix

### DIFF
--- a/TrackerGG/client.py
+++ b/TrackerGG/client.py
@@ -37,6 +37,7 @@ class TrackerClient:
 
     :param api_key: :class:`str` Tracker API Key.
     """
+
     api_key: str
     loop: asyncio.AbstractEventLoop
     http_client: HTTPClient
@@ -59,6 +60,7 @@ class CSGOClient(TrackerClient):
 
     :param api_key: :class:`str` Tracker API Key.
     """
+
     def __init__(self, api_key: str) -> None:
         super().__init__(api_key)
 

--- a/TrackerGG/client.py
+++ b/TrackerGG/client.py
@@ -19,6 +19,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 import asyncio
 import json
 from typing import List, Union
+import sys
 
 from .Models import CSGOProfile
 from .Models import CSGOMapSegment
@@ -42,7 +43,11 @@ class TrackerClient:
     http_client: HTTPClient
 
     def __init__(self, api_key: str) -> None:
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+        try:
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+        except AttributeError:
+            pass
+
         self.loop = asyncio.get_event_loop()
         self.api_key = api_key
         self.http_client = HTTPClient(self.loop, self.api_key)

--- a/TrackerGG/client.py
+++ b/TrackerGG/client.py
@@ -19,7 +19,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 import asyncio
 import json
 from typing import List, Union
-import sys
 
 from .Models import CSGOProfile
 from .Models import CSGOMapSegment


### PR DESCRIPTION
Features

- Fix `AttributeError` on non-Windows environment.

```py
asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
```

to 

```py
try:
    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
except AttributeError:
    pass
```

- Remove unused import syntax
- Reformat codes