### PR TITLE
Implement replaceable HTTP Client 

### DIFF
--- a/TrackerGG/HTTPClients/__init__.py
+++ b/TrackerGG/HTTPClients/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (c) 2023 DevRuby
+MIT License
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NON INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+from .abstract_http_client import AbstractHTTPClient
+from .httpclient import HTTPClientLibrary
+from .httpclient import RequestMethod
+from .httpclient import ResponseData
+from .httpclient import Route
+from .httpclient import get_http_client

--- a/TrackerGG/HTTPClients/abstract_http_client.py
+++ b/TrackerGG/HTTPClients/abstract_http_client.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (c) 2023 DevRuby
+MIT License
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NON INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+from abc import *
+from typing import Optional, Dict
+
+from .httpclient import ResponseData, Route
+
+
+class AbstractHTTPClient(metaclass=ABCMeta):
+    def __new__(cls, *args, **kwargs):
+        if not hasattr(cls, "_instance"):
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    @abstractmethod
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    async def request(self, route: Route, headers: Optional[Dict[str, str]] = None) -> ResponseData:
+        pass

--- a/TrackerGG/HTTPClients/httpclient.py
+++ b/TrackerGG/HTTPClients/httpclient.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (c) 2023 DevRuby
+MIT License
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NON INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+import asyncio
+from enum import Enum, auto
+from typing import ClassVar, Optional, Dict, Any
+
+
+class Missing:
+    pass
+
+
+MISSING: Any = Missing()
+
+
+class HTTPClientLibrary(Enum):
+    AIOHTTP = auto()
+    HTTPX = auto()
+
+
+def get_http_client(
+    loop: asyncio.AbstractEventLoop, api_key: str, lib: Optional[HTTPClientLibrary] = None
+):
+    if lib is None:
+        try:
+            import aiohttp
+            from .aiohttp_client import AiohttpHTTPClient
+
+            return AiohttpHTTPClient(loop, api_key)
+        except ImportError:
+            pass
+
+        try:
+            import httpx
+            from .httpx_client import HttpxHTTPClient
+
+            return HttpxHTTPClient(loop, api_key)
+        except ImportError:
+            pass
+
+        raise ImportError("At least one of aiohttp or httpx libraries is required")
+
+    if lib == HTTPClientLibrary.HTTPX:
+        from .httpx_client import HttpxHTTPClient
+
+        return HttpxHTTPClient(loop, api_key)
+
+    elif lib == HTTPClientLibrary.AIOHTTP:
+        from .aiohttp_client import AiohttpHTTPClient
+
+        return AiohttpHTTPClient(loop, api_key)
+
+
+class RequestMethod(Enum):
+    GET = 0
+    POST = 1
+    PUT = 2
+    HEAD = 3
+    DELETE = 4
+    PATCH = 5
+    OPTIONS = 6
+
+
+class Route:
+    BASE_URL: ClassVar[str] = "https://public-api.tracker.gg/v2"
+
+    @staticmethod
+    def __make_url(url: str, params: dict) -> str:
+        first: bool = True
+        for key, val in params.items():
+            url += "%s%s=%s" % ("?" if first else "&", key, str(val))
+            first = False
+        return url
+
+    def __init__(self, method: RequestMethod, url: str, params: Optional[Dict[str, Any]] = None) -> None:
+        if params:
+            url = self.__make_url(url, params)
+        self.url: str = self.BASE_URL + url
+        self.method: RequestMethod = method
+
+
+class ResponseData:
+    def __init__(self, text: str, status: int) -> None:
+        self.response_data: str = text
+        self.status: int = status
+
+    def __str__(self) -> str:
+        return f"status_code : {self.status}\nresponse_data : {self.response_data}"

--- a/TrackerGG/HTTPClients/httpx_client.py
+++ b/TrackerGG/HTTPClients/httpx_client.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (c) 2023 DevRuby
+MIT License
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NON INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+import asyncio
+from typing import ClassVar, Optional, Union, Dict
+
+import httpx
+
+from .abstract_http_client import AbstractHTTPClient
+from .httpclient import ResponseData, Route
+
+
+class HttpxHTTPClient(AbstractHTTPClient):
+    USER_AGENT: ClassVar[str] = "Mozilla/5.0"
+
+    def __new__(cls, *args, **kwargs):
+        if not hasattr(cls, "_instance"):
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self, loop: asyncio.AbstractEventLoop, api_key: str) -> None:
+        self.loop: asyncio.AbstractEventLoop = loop
+        self.lock: asyncio.Lock = asyncio.Lock()
+        self.api_key: str = api_key
+
+    async def request(self, route: Route, headers: Optional[Dict[str, str]] = None) -> ResponseData:
+        if not headers:
+            headers = {}
+
+        default_header = {
+            "User-Agent": self.USER_AGENT,
+            "Accept": "application/json",
+            "Accept-Encoding": "gzip",
+            "TRN-Api-Key": self.api_key,
+            "Host": "public-api.tracker.gg",
+            "Connection": "keep-alive",
+            "TE": "trailers",
+            "Upgrade-Insecure-Requests": "1",
+        }
+
+        headers.update(default_header)
+
+        async with self.lock:
+            async with httpx.AsyncClient() as client:
+                response: httpx.Response = await client.request(
+                    method=route.method.name, url=route.url, headers=headers
+                )
+                status: int = response.status_code
+                text: str = response.text
+                return ResponseData(text, status)

--- a/TrackerGG/__init__.py
+++ b/TrackerGG/__init__.py
@@ -37,3 +37,21 @@ from .client import CSGOClient
 from .client import ApexClient
 
 from . import utils
+
+
+count = 0
+
+try:
+    import aiohttp
+    count += 1
+except ImportError:
+    pass
+
+try:
+    import httpx
+    count += 1
+except ImportError:
+    pass
+
+if count == 0:
+    raise ImportError("\nAt least one of aiohttp or httpx libraries is required\nTry `pip install aiohttp` or `pip install httpx`")

--- a/TrackerGG/client.py
+++ b/TrackerGG/client.py
@@ -18,20 +18,16 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 import asyncio
 import json
-from typing import List, Union
+from typing import List, Union, Optional
 
-from .Models import CSGOProfile
-from .Models import CSGOMapSegment
-from .Models import CSGOWeaponSegment
-from .Models import CSGOQueryData
+from .HTTPClients import *
 from .Models import ApexProfile
 from .Models import ApexQueryData
+from .Models import CSGOMapSegment
+from .Models import CSGOProfile
+from .Models import CSGOQueryData
+from .Models import CSGOWeaponSegment
 from .Models import Platform
-
-from .httpclient import HTTPClient
-from .httpclient import RequestMethod
-from .httpclient import ResponseData
-from .httpclient import Route
 
 
 class TrackerClient:
@@ -44,9 +40,9 @@ class TrackerClient:
 
     api_key: str
     loop: asyncio.AbstractEventLoop
-    http_client: HTTPClient
+    http_client: AbstractHTTPClient
 
-    def __init__(self, api_key: str) -> None:
+    def __init__(self, api_key: str, http_client: Optional[HTTPClientLibrary] = None) -> None:
         try:
             asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
         except AttributeError:
@@ -54,7 +50,7 @@ class TrackerClient:
 
         self.loop = asyncio.get_event_loop()
         self.api_key = api_key
-        self.http_client = HTTPClient(self.loop, self.api_key)
+        self.http_client = get_http_client(self.loop, self.api_key)
 
 
 class CSGOClient(TrackerClient):

--- a/test.py
+++ b/test.py
@@ -1,6 +1,5 @@
 import unittest
 import asyncio
-import time
 
 import TrackerGG
 
@@ -12,19 +11,19 @@ loop = asyncio.get_event_loop()
 csgo_profile_list = ["hiveruby"]
 
 
-class Test(unittest.TestCase):
+class CSGOTest(unittest.TestCase):
     def test_get_profile(self):
         for p in csgo_profile_list:
-            loop.run_until_complete(csgo_client.get_profile(p))
+            print(loop.run_until_complete(csgo_client.get_profile(p)))
 
     def test_get_map_segment(self):
         for p in csgo_profile_list:
-            loop.run_until_complete(csgo_client.get_map_segment(p))
+            print(loop.run_until_complete(csgo_client.get_map_segment(p)))
 
     def test_get_weapon_segment(self):
         for p in csgo_profile_list:
-            loop.run_until_complete(csgo_client.get_weapon_segment(p))
+            print(loop.run_until_complete(csgo_client.get_weapon_segment(p)))
 
     def test_search_profile(self):
         for p in csgo_profile_list:
-            loop.run_until_complete(csgo_client.search_profile(p))
+            print(loop.run_until_complete(csgo_client.search_profile(p)))


### PR DESCRIPTION
- TrackerGG/HTTPClients/httpclient.py: Add `get_http_client` method; Move`AiohttpHTTPClient` to `TrackerGG/HTTPClients/aiohttp_client.py`
- TrackerGG/HTTPClients/abstract_http_client.py: Add `AbstractHTTPClient` abstract class
- TrackerGG/HTTPClients/aiohttp_client.py: Add `AiohttpHTTPClient` class
- TrackerGG/HTTPClients/httpx_clinet.py: Add `HttpxHTTPClient` class
- TrackerGG/HTTPClients/__init__.py: Import `AbstractHTTPClient` class, `HTTPClientLibrary` class, `RequestMethod` class, `ResponseData` class, `Route` class, `get_http_client` method
- TrackerGG/__init__.py: Check modules